### PR TITLE
Add php-http/client-common to composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An awesome object oriented wrapper for the Harvest REST API v2, written with and
 Via Composer:
 
 ```
-composer require wearerequired/harvest-api-php-client php-http/guzzle6-adapter "^2.0"
+composer require wearerequired/harvest-api-php-client php-http/guzzle6-adapter "^2.0" php-http/client-common
 ```
 
 Why `php-http/guzzle6-adapter`? The library is decoupled from any HTTP messaging client with the help by [HTTPlug](http://httplug.io/).


### PR DESCRIPTION
Else you get a nice

```PHP Fatal error:  Interface 'Http\Client\Common\Plugin' not found in /Users/guill/Development/alfred-time/vendor/wearerequired/harvest-api-php-client/src/HttpClient/Plugin/ResponseExceptionThrower.php on line 23```

when using the package.