### PR TITLE
Ensure updated_since is a ISO 8601 formatted string

### DIFF
--- a/src/Api/Clients.php
+++ b/src/Api/Clients.php
@@ -32,7 +32,7 @@ class Clients extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Contacts.php
+++ b/src/Api/Contacts.php
@@ -31,7 +31,7 @@ class Contacts extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/contacts', $parameters );

--- a/src/Api/CurrentUser/ProjectAssignments.php
+++ b/src/Api/CurrentUser/ProjectAssignments.php
@@ -29,7 +29,7 @@ class ProjectAssignments extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/users/me/project_assignments', $parameters );

--- a/src/Api/Estimate/Messages.php
+++ b/src/Api/Estimate/Messages.php
@@ -32,7 +32,7 @@ class Messages extends AbstractApi {
 	 */
 	public function all( int $estimateId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/estimates/' . rawurlencode( $estimateId ) . '/messages', $parameters );

--- a/src/Api/EstimateItemCategories.php
+++ b/src/Api/EstimateItemCategories.php
@@ -30,7 +30,7 @@ class EstimateItemCategories extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/estimate_item_categories', $parameters );

--- a/src/Api/Estimates.php
+++ b/src/Api/Estimates.php
@@ -37,7 +37,7 @@ class Estimates extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['from'] ) && $parameters['from'] instanceof DateTime ) {

--- a/src/Api/ExpenseCategories.php
+++ b/src/Api/ExpenseCategories.php
@@ -33,7 +33,7 @@ class ExpenseCategories extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Expenses.php
+++ b/src/Api/Expenses.php
@@ -37,7 +37,7 @@ class Expenses extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['from'] ) && $parameters['from'] instanceof DateTime ) {

--- a/src/Api/Invoice/Messages.php
+++ b/src/Api/Invoice/Messages.php
@@ -32,7 +32,7 @@ class Messages extends AbstractApi {
 	 */
 	public function all( int $invoiceId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/invoices/' . rawurlencode( $invoiceId ) . '/messages', $parameters );

--- a/src/Api/Invoice/Payments.php
+++ b/src/Api/Invoice/Payments.php
@@ -32,7 +32,7 @@ class Payments extends AbstractApi {
 	 */
 	public function all( int $invoiceId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/invoices/' . rawurlencode( $invoiceId ) . '/payments', $parameters );

--- a/src/Api/InvoiceItemCategories.php
+++ b/src/Api/InvoiceItemCategories.php
@@ -30,7 +30,7 @@ class InvoiceItemCategories extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/invoice_item_categories', $parameters );

--- a/src/Api/Invoices.php
+++ b/src/Api/Invoices.php
@@ -37,7 +37,7 @@ class Invoices extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['from'] ) && $parameters['from'] instanceof DateTime ) {

--- a/src/Api/Project/TaskAssignments.php
+++ b/src/Api/Project/TaskAssignments.php
@@ -34,7 +34,7 @@ class TaskAssignments extends AbstractApi {
 	 */
 	public function all( int $projectId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Project/UserAssignments.php
+++ b/src/Api/Project/UserAssignments.php
@@ -34,7 +34,7 @@ class UserAssignments extends AbstractApi {
 	 */
 	public function all( int $projectId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -33,7 +33,7 @@ class Projects extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/TaskAssignments.php
+++ b/src/Api/TaskAssignments.php
@@ -30,7 +30,7 @@ class TaskAssignments extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Tasks.php
+++ b/src/Api/Tasks.php
@@ -32,7 +32,7 @@ class Tasks extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/TimeEntries.php
+++ b/src/Api/TimeEntries.php
@@ -39,7 +39,7 @@ class TimeEntries extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format(DateTime::ATOM);
 		}
 
 		if ( isset( $parameters['from'] ) && $parameters['from'] instanceof DateTime ) {

--- a/src/Api/TimeEntries.php
+++ b/src/Api/TimeEntries.php
@@ -39,7 +39,7 @@ class TimeEntries extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format(DateTime::ATOM);
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['from'] ) && $parameters['from'] instanceof DateTime ) {

--- a/src/Api/User/ProjectAssignments.php
+++ b/src/Api/User/ProjectAssignments.php
@@ -30,7 +30,7 @@ class ProjectAssignments extends AbstractApi {
 	 */
 	public function all( int $userId, array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		$result = $this->get( '/users/' . rawurlencode( $userId ) . '/project_assignments', $parameters );

--- a/src/Api/UserAssignments.php
+++ b/src/Api/UserAssignments.php
@@ -30,7 +30,7 @@ class UserAssignments extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -32,7 +32,7 @@ class Users extends AbstractApi {
 	 */
 	public function all( array $parameters = [] ) {
 		if ( isset( $parameters['updated_since'] ) && $parameters['updated_since'] instanceof DateTime ) {
-			$parameters['updated_since'] = $parameters['updated_since']->format( 'Y-m-d H:i' );
+			$parameters['updated_since'] = $parameters['updated_since']->format( DateTime::ATOM );
 		}
 
 		if ( isset( $parameters['is_active'] ) ) {

--- a/tests/Api/ClientsTest.php
+++ b/tests/Api/ClientsTest.php
@@ -117,7 +117,7 @@ class ClientsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/clients', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/clients', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -68,7 +68,7 @@ class ContactsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/contacts', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/contacts', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/CurrentUser/ProjectAssignmentsTest.php
+++ b/tests/Api/CurrentUser/ProjectAssignmentsTest.php
@@ -69,7 +69,7 @@ class ProjectAssignmentsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/users/me/project_assignments', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/users/me/project_assignments', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/ExpensesTest.php
+++ b/tests/Api/ExpensesTest.php
@@ -68,7 +68,7 @@ class ExpensesTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/expenses', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/expenses', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/InvoicesTest.php
+++ b/tests/Api/InvoicesTest.php
@@ -68,7 +68,7 @@ class InvoicesTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/invoices', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/invoices', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/Project/TaskAssignmentsTest.php
+++ b/tests/Api/Project/TaskAssignmentsTest.php
@@ -75,7 +75,7 @@ class TaskAssignmentsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( "/projects/{$this->projectId}/task_assignments", [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( "/projects/{$this->projectId}/task_assignments", [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( $this->projectId, [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/Project/UserAssignmentsTest.php
+++ b/tests/Api/Project/UserAssignmentsTest.php
@@ -75,7 +75,7 @@ class UserAssignmentsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( "/projects/{$this->projectId}/user_assignments", [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( "/projects/{$this->projectId}/user_assignments", [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( $this->projectId, [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -118,7 +118,7 @@ class ProjectsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/projects', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/projects', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/TaskAssignmentsTest.php
+++ b/tests/Api/TaskAssignmentsTest.php
@@ -68,7 +68,7 @@ class TaskAssignmentsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/task_assignments', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/task_assignments', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/TasksTest.php
+++ b/tests/Api/TasksTest.php
@@ -116,7 +116,7 @@ class TasksTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/tasks', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/tasks', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/TimeEntriesTest.php
+++ b/tests/Api/TimeEntriesTest.php
@@ -72,7 +72,7 @@ class TimeEntriesTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/time_entries', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/time_entries', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/UserAssignmentsTest.php
+++ b/tests/Api/UserAssignmentsTest.php
@@ -68,7 +68,7 @@ class UserAssignmentsTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/user_assignments', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/user_assignments', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -117,7 +117,7 @@ class UsersTest extends TestCase {
 		$api = $this->getApiMock();
 		$api->expects( $this->once() )
 			->method( 'get' )
-			->with( '/users', [ 'updated_since' => $updatedSince->format( 'Y-m-d H:i' ) ] )
+			->with( '/users', [ 'updated_since' => $updatedSince->format( DateTime::ATOM ) ] )
 			->will( $this->returnValue( $response ) );
 
 		$this->assertEquals( $expectedArray, $api->all( [ 'updated_since' => $updatedSince ] ) );


### PR DESCRIPTION
With hours and minutes in the string passed in as 24 hours before today (with minutes e.t.c.)

This caused a response error about an invalidate date format. This no longer happens with this

```
$date->add(DateInterval::createFromDateString('yesterday'));
echo $date->format('F j, Y') . "\n";
$timeEntries = $client->timeEntries()->all(['updated_since' =>  $date]);
```