### PR TITLE
Undefined class fix

### DIFF
--- a/src/Api/Invoices.php
+++ b/src/Api/Invoices.php
@@ -6,10 +6,10 @@
 namespace Required\Harvest\Api;
 
 use DateTime;
-use Required\Harvest\Api\Invoice\PaymentsInterface;
-use Required\Harvest\Api\Invoice\Payments;
 use Required\Harvest\Api\Invoice\Messages;
 use Required\Harvest\Api\Invoice\MessagesInterface;
+use Required\Harvest\Api\Invoice\Payments;
+use Required\Harvest\Api\Invoice\PaymentsInterface;
 
 /**
  * API client for invoices endpoint.

--- a/src/Api/Invoices.php
+++ b/src/Api/Invoices.php
@@ -6,8 +6,8 @@
 namespace Required\Harvest\Api;
 
 use DateTime;
-use Lafiel\Required\Harvest\Api\Invoice\PaymentInterface;
-use Lafiel\Required\Harvest\Api\Invoice\Payments;
+use Required\Harvest\Api\Invoice\PaymentsInterface;
+use Required\Harvest\Api\Invoice\Payments;
 use Required\Harvest\Api\Invoice\Messages;
 use Required\Harvest\Api\Invoice\MessagesInterface;
 
@@ -200,9 +200,9 @@ class Invoices extends AbstractApi implements InvoicesInterface {
 	/**
 	 * Gets the authenticated user's project assignments.
 	 *
-	 * @return \Lafiel\Required\Harvest\Api\Invoice\PaymentInterface ;
+	 * @return \Required\Harvest\Api\Invoice\PaymentsInterface ;
 	 */
-	public function payments(): PaymentInterface {
+	public function payments(): PaymentsInterface {
 		return new Payments( $this->client );
 	}
 

--- a/src/Api/InvoicesInterface.php
+++ b/src/Api/InvoicesInterface.php
@@ -2,7 +2,7 @@
 
 namespace Required\Harvest\Api;
 
-use Lafiel\Required\Harvest\Api\Invoice\PaymentInterface;
+use Required\Harvest\Api\Invoice\PaymentsInterface;
 use Required\Harvest\Api\Invoice\MessagesInterface;
 
 /**
@@ -107,9 +107,9 @@ interface InvoicesInterface {
 	/**
 	 * Gets the authenticated user's project assignments.
 	 *
-	 * @return \Lafiel\Required\Harvest\Api\Invoice\PaymentInterface ;
+	 * @return \Required\Harvest\Api\Invoice\PaymentsInterface ;
 	 */
-	public function payments(): PaymentInterface;
+	public function payments(): PaymentsInterface;
 
 	/**
 	 * Gets a Estimate's messages.

--- a/src/Api/InvoicesInterface.php
+++ b/src/Api/InvoicesInterface.php
@@ -2,8 +2,8 @@
 
 namespace Required\Harvest\Api;
 
-use Required\Harvest\Api\Invoice\PaymentsInterface;
 use Required\Harvest\Api\Invoice\MessagesInterface;
+use Required\Harvest\Api\Invoice\PaymentsInterface;
 
 /**
  * API client for invoices endpoint.


### PR DESCRIPTION
Fix for "Error: Class 'Lafiel\Required\Harvest\Api\Invoice\Payments' not found"

I suspect the package has either be renamed or parts were copied from somewhere else.
This should fix the naming inconsistency and make it possible to use the payments part of the API on invoices. 