### PR TITLE
Serveral response fixes

### DIFF
--- a/src/Api/Estimate/Messages.php
+++ b/src/Api/Estimate/Messages.php
@@ -36,11 +36,11 @@ class Messages extends AbstractApi implements MessagesInterface {
 		}
 
 		$result = $this->get( '/estimates/' . rawurlencode( $estimateId ) . '/messages', $parameters );
-		if ( ! isset( $result['messages'] ) || ! \is_array( $result['messages'] ) ) {
+		if ( ! isset( $result['estimate_messages'] ) || ! \is_array( $result['estimate_messages'] ) ) {
 			throw new \Required\Harvest\Exception\RuntimeException( 'Unexpected result.' );
 		}
 
-		return $result['messages'];
+		return $result['estimate_messages'];
 	}
 
 	/**

--- a/src/Api/Invoice/Messages.php
+++ b/src/Api/Invoice/Messages.php
@@ -36,11 +36,11 @@ class Messages extends AbstractApi implements MessagesInterface {
 		}
 
 		$result = $this->get( '/invoices/' . rawurlencode( $invoiceId ) . '/messages', $parameters );
-		if ( ! isset( $result['messages'] ) || ! \is_array( $result['messages'] ) ) {
+		if ( ! isset( $result['invoice_messages'] ) || ! \is_array( $result['invoice_messages'] ) ) {
 			throw new \Required\Harvest\Exception\RuntimeException( 'Unexpected result.' );
 		}
 
-		return $result['messages'];
+		return $result['invoice_messages'];
 	}
 
 	/**

--- a/src/Api/Invoice/Payments.php
+++ b/src/Api/Invoice/Payments.php
@@ -36,11 +36,11 @@ class Payments extends AbstractApi implements PaymentsInterface {
 		}
 
 		$result = $this->get( '/invoices/' . rawurlencode( $invoiceId ) . '/payments', $parameters );
-		if ( ! isset( $result['payments'] ) || ! \is_array( $result['payments'] ) ) {
+		if ( ! isset( $result['invoice_payments'] ) || ! \is_array( $result['invoice_payments'] ) ) {
 			throw new \Required\Harvest\Exception\RuntimeException( 'Unexpected result.' );
 		}
 
-		return $result['payments'];
+		return $result['invoice_payments'];
 	}
 
 	/**

--- a/src/Api/Invoices.php
+++ b/src/Api/Invoices.php
@@ -34,7 +34,7 @@ class Invoices extends AbstractApi implements InvoicesInterface {
 	 *     @type DateTime|string $from          Only return invoices with a `issue_date` on or after the given date.
 	 *     @type DateTime|string $to            Only return invoices with a `issue_date` on or after the given date.
 	 *     @type string           $state        Only return invoices with a `state` matching the value provided.
-	 *                                          Options: 'draft', 'sent', 'accepted', or 'declined'.
+	 *                                          Options: 'draft', 'open', 'paid', or 'closed'.
 	 * }
 	  * @return array|string
 	 */
@@ -51,7 +51,7 @@ class Invoices extends AbstractApi implements InvoicesInterface {
 			$parameters['to'] = $parameters['to']->format( 'Y-m-d' );
 		}
 
-		$state_options = [ 'draft', 'sent', 'accepted', 'declined' ];
+		$state_options = [ 'draft', 'open', 'paid', 'closed' ];
 		if ( isset( $parameters['state'] ) && ! \in_array( $parameters['state'], $state_options, true ) ) {
 			throw new \Required\Harvest\Exception\InvalidArgumentException(
 				sprintf(


### PR DESCRIPTION
1. Invoices.php
Available state options are `'draft', 'open', 'paid', or 'closed'` instead of `'draft', 'sent', 'accepted', or 'declined'`
https://help.getharvest.com/api-v2/invoices-api/invoices/invoices/#list-all-invoices

2. Invoice/Payments.php
Response key for the payments is `invoice_payments` instead `payments`
https://help.getharvest.com/api-v2/invoices-api/invoices/invoice-payments/#list-all-payments-for-an-invoice

3. Invoice/Messages.php
Response key for the payments is `invoice_messages` instead `messages`
https://help.getharvest.com/api-v2/invoices-api/invoices/invoice-messages/#list-all-messages-for-an-invoice

4. Estimate/Messages.php
Response key for the payments is `estimate_messages` instead `messages`
https://help.getharvest.com/api-v2/estimates-api/estimates/estimate-messages/#list-all-messages-for-an-estimate