### PR TITLE
Fix condition for spent_date parameter for expenses

### DIFF
--- a/src/Api/Expenses.php
+++ b/src/Api/Expenses.php
@@ -103,8 +103,12 @@ class Expenses extends AbstractApi implements ExpensesInterface {
 			throw new \Required\Harvest\Exception\InvalidArgumentException( 'The "expense_category_id" parameter must be a non-empty integer.' );
 		}
 
-		if ( ! \is_string( $parameters['spent_date'] ) || $parameters['spent_date'] instanceof DateTime ) {
+		if ( ! \is_string( $parameters['spent_date'] ) && ! $parameters['spent_date'] instanceof DateTime ) {
 			throw new \Required\Harvest\Exception\InvalidArgumentException( 'The "spent_date" parameter must be DateTime instance or an ISO 8601 formatted date string.' );
+		}
+
+		if ( $parameters['spent_date'] instanceof DateTime ) {
+			$parameters['spent_date'] = $parameters['spent_date']->format( DateTime::ATOM );
 		}
 
 		return $this->post( '/expenses', $parameters );

--- a/src/Api/TimeEntries.php
+++ b/src/Api/TimeEntries.php
@@ -111,8 +111,12 @@ class TimeEntries extends AbstractApi implements TimeEntriesInterface {
 			throw new \Required\Harvest\Exception\InvalidArgumentException( 'The "task_id" parameter must be a non-empty integer.' );
 		}
 
-		if ( ! \is_string( $parameters['spent_date'] ) || $parameters['spent_date'] instanceof DateTime ) {
+		if ( ! \is_string( $parameters['spent_date'] ) && ! $parameters['spent_date'] instanceof DateTime ) {
 			throw new \Required\Harvest\Exception\InvalidArgumentException( 'The "spent_date" parameter must be DateTime instance or an ISO 8601 formatted date string.' );
+		}
+
+		if ( $parameters['spent_date'] instanceof DateTime ) {
+			$parameters['spent_date'] = $parameters['spent_date']->format( DateTime::ATOM );
 		}
 
 		return $this->post( '/time_entries', $parameters );

--- a/tests/Api/ExpensesTest.php
+++ b/tests/Api/ExpensesTest.php
@@ -292,6 +292,37 @@ class ExpensesTest extends TestCase {
 	}
 
 	/**
+	 * Test creating new expense with date time object.
+	 */
+	public function testCreateNewWithDateTime() {
+		$expectedArray = $this->getFixture( 'expense-15297032' );
+
+		$data_input = [
+			'user_id'             => 1782959,
+			'project_id'          => 14308069,
+			'expense_category_id' => 4195926,
+			'spent_date'          => date_create( '2017-03-01' ),
+			'total_cost'          => 13.59,
+		];
+
+		$data_response = [
+			'user_id'             => 1782959,
+			'project_id'          => 14308069,
+			'expense_category_id' => 4195926,
+			'spent_date'          => '2017-03-01T00:00:00+00:00',
+			'total_cost'          => 13.59,
+		];
+
+		$api = $this->getApiMock();
+		$api->expects( $this->once() )
+			->method( 'post' )
+			->with( '/expenses', $data_response )
+			->will( $this->returnValue( $expectedArray ) );
+
+		$this->assertEquals( $expectedArray, $api->create( $data_input ) );
+	}
+
+	/**
 	 * Test updating expense.
 	 */
 	public function testUpdate() {

--- a/tests/Api/TimeEntriesTest.php
+++ b/tests/Api/TimeEntriesTest.php
@@ -323,6 +323,37 @@ class TimeEntriesTest extends TestCase {
 	}
 
 	/**
+	 * Test creating new time entry with date time object.
+	 */
+	public function testCreateNewWithDateTimeAsSpentDate() {
+		$expectedArray = $this->getFixture( 'time-entry-636718192' );
+
+		$data_input = [
+			'user_id'    => 1782959,
+			'project_id' => 14307913,
+			'task_id'    => 8083365,
+			'spent_date' => date_create( '2017-03-01' ),
+			'hours'      => 1.0,
+		];
+
+		$data_response = [
+			'user_id'    => 1782959,
+			'project_id' => 14307913,
+			'task_id'    => 8083365,
+			'spent_date' => '2017-03-01T00:00:00+00:00',
+			'hours'      => 1.0,
+		];
+
+		$api = $this->getApiMock();
+		$api->expects( $this->once() )
+			->method( 'post' )
+			->with( '/time_entries', $data_response )
+			->will( $this->returnValue( $expectedArray ) );
+
+		$this->assertEquals( $expectedArray, $api->create( $data_input ) );
+	}
+
+	/**
 	 * Test updating time entry.
 	 */
 	public function testUpdate() {


### PR DESCRIPTION
If a DateTime object is provided, format it into the required format for the API.

